### PR TITLE
translate enhancer : add displayName to the translated Component.

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -1,5 +1,13 @@
 import { connect } from 'react-redux';
 import { getP } from './selectors';
 
+const getDisplayName = WrappedComponent => (
+    WrappedComponent.displayName || WrappedComponent.name || 'Component'
+);
+
 const mapStateToProps = state => ({ p: getP(state) });
-export const translate = connect(mapStateToProps);
+export const translate = Component => {
+    const Connected = connect(mapStateToProps)(Component);
+    Connected.displayName = `Translated(${getDisplayName(Connected.WrappedComponent)})`;
+    return Connected;
+};

--- a/src/translate.spec.js
+++ b/src/translate.spec.js
@@ -11,24 +11,46 @@ const fakeStore = createStore(createRootReducer(), {
     polyglot: { locale: 'en', phrases: { hello: 'hello' } },
 });
 
-const DummyComponent = ({ p }) => (
-    <div
-        data-t={p.t('hello')}
-        data-tc={p.tc('hello')}
-        data-tu={p.tu('hello')}
-    />
-);
+const createAnonymousComponent = () => () => (<div />);
+
+const DummyComponentWithDisplayName = createAnonymousComponent();
+const name = 'DummyComponent';
+DummyComponentWithDisplayName.displayName = name;
 
 describe('translate enhancer', () => {
+    const DummyComponent = ({ p }) => (
+        <div
+            data-t={p.t('hello')}
+            data-tc={p.tc('hello')}
+            data-tu={p.tu('hello')}
+        />
+    );
+    const EnhancedComponent = translate(DummyComponent);
+
+    const tree = renderer.create(
+        <Provider store={fakeStore}>
+            <EnhancedComponent />
+        </Provider>
+    ).toJSON();
+
     it('should provide a valid p object.', () => {
-        const EnhancedComponent = translate(DummyComponent);
-        const tree = renderer.create(
-            <Provider store={fakeStore}>
-                <EnhancedComponent />
-            </Provider>
-        ).toJSON();
         expect(tree.props['data-t']).toBe('hello');
         expect(tree.props['data-tc']).toBe('Hello');
         expect(tree.props['data-tu']).toBe('HELLO');
+    });
+
+    describe('displayName', () => {
+        it('should have a valid displayName', () => {
+            const translatedName = `Translated(${name})`;
+            expect(EnhancedComponent.displayName).toBe(translatedName);
+            expect(translate(DummyComponentWithDisplayName).displayName)
+                .toBe(translatedName);
+        });
+
+        it('shoudld have a default name when it is an anonymous component', () => {
+            const translatedDefaultName = 'Translated(Component)';
+            const TranslatedComponent = translate(createAnonymousComponent());
+            expect(TranslatedComponent.displayName).toBe(translatedDefaultName);
+        });
     });
 });


### PR DESCRIPTION
```
const DummyComponent = () => <div />
// translate(Component).displayName will be 'Translated(DummyComponent)'
```
