### PR TITLE
remove ramda from dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "node-polyglot": "^2.0.0",
-    "ramda": "^0.22.1",
     "redux": "^3.6.0",
     "reselect": "^2.5.4"
   },
@@ -42,6 +41,7 @@
     "eslint-plugin-jsx-a11y": "^2.2.1",
     "eslint-plugin-react": "^6.2.0",
     "jest": "^15.1.1",
+    "ramda": "^0.22.1",
     "react": "^15.3.0",
     "react-redux": "^4.4.5",
     "react-test-renderer": "^15.3.2",

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,8 +1,10 @@
-import { is } from 'ramda';
 import { setLanguage } from './actions';
 
-const isString = is(String);
-const isFunction = is(Function);
+// eslint-disable-next-line valid-typeof
+const is = type => x => typeof x === type;
+
+const isString = is('string');
+const isFunction = is('function');
 const isArray = Array.isArray;
 
 const checkParams = (catchedAction, getLocale, getPhrases) => {

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,8 +1,13 @@
-import { path, compose, adjust, toUpper, join } from 'ramda';
+import { compose } from 'redux';
 import { createSelector } from 'reselect';
 import Polyglot from 'node-polyglot';
 
-const capitalize = compose(join(''), adjust(toUpper, 0));
+const path = arrPath => obj => arrPath.reduce((cursor, key) => cursor && cursor[key], obj);
+const toUpper = str => str.toUpperCase();
+const adjustString = (f, index) => str => (
+    str.substr(0, index) + f(str[index]) + str.substr(index + 1)
+);
+const capitalize = adjustString(toUpper, 0);
 
 const getLocale = path(['polyglot', 'locale']);
 const getPhrases = path(['polyglot', 'phrases']);

--- a/src/selectors.spec.js
+++ b/src/selectors.spec.js
@@ -1,7 +1,20 @@
-import { toUpper, curry, evolve, is, pipe, values, all, equals } from 'ramda';
+import { toUpper, evolve, is, pipe, values, all, equals } from 'ramda';
 import { getP, getLocale } from './selectors';
 
-const on = curry((x, f) => f(x));
+const isValidPolyglot = pipe(
+    evolve({
+        phrases: is(Object),
+        currentLocale: is(String),
+        allowMissing: is(Boolean),
+        warn: is(Function),
+        t: is(Function),
+        tc: is(Function),
+        tu: is(Function),
+        tm: is(Function),
+    }),
+    values,
+    all(equals(true)),
+);
 
 const fakeState = {
     polyglot: {
@@ -25,22 +38,7 @@ describe('selectors', () => {
         const p = getP(fakeState);
 
         it('gives a valid redux-polyglot object', () => {
-            expect(
-                on(p)(pipe(
-                    evolve({
-                        phrases: is(Object),
-                        currentLocale: is(String),
-                        allowMissing: is(Boolean),
-                        warn: is(Function),
-                        t: is(Function),
-                        tc: is(Function),
-                        tu: is(Function),
-                        tm: is(Function),
-                    }),
-                    values,
-                    all(equals(true)),
-                ))
-            ).toBe(true);
+            expect(isValidPolyglot(p)).toBe(true);
         });
 
         it('doesn\'t crash when state is an empty object', () => {


### PR DESCRIPTION
note: ramda is still used in *.spec.js, so we keep it in devDependency.
