### PR TITLE
Changed: Remove React references, to be moved to react-redux-polyglot

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,8 @@
   "keywords": [
     "polyglot",
     "redux",
-    "react",
     "i18n",
     "reselect",
-    "component enhancer",
     "translation"
   ],
   "maintainers": [
@@ -80,15 +78,8 @@
     "eslint-plugin-react": "^6.2.0",
     "jest": "^15.1.1",
     "ramda": "^0.22.1",
-    "react": "^15.3.0",
-    "react-redux": "^4.4.5",
-    "react-test-renderer": "^15.3.2",
     "rimraf": "^2.5.4",
     "shelljs": "^0.7.4",
     "webpack": "^1.13.2"
-  },
-  "peerDependencies": {
-    "react": "^15.3.0",
-    "react-redux": "^4.4.5"
   }
 }


### PR DESCRIPTION
Just the first step of (re)moving React stuff, now that we created redux-polyglot
