### PR TITLE
Add createGetP function

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,20 @@ You can use the `getLocale()` selector inside a [mapStateToProps](https://github
 
 Proptype: ````locale: PropTypes.string,````
 
+### Use polyglot options
+if you want to use `onMissingKey`, `allowMissing` or `warn` [polyglot](http://airbnb.io/polyglot.js/) options, you can use the `createGetP` function to create a custom `getP`.
+
+usage :
+```js
+import { createGetP } from 'redux-polyglot';
+
+const options = {
+  allowMissing: true,
+}
+
+export const getP = createGetP(options);
+```
+
 ## Team
 
 These folks keep the project moving and are resources for help:

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -12,16 +12,20 @@ const capitalize = adjustString(toUpper, 0);
 
 const getLocale = path(['polyglot', 'locale']);
 const getPhrases = path(['polyglot', 'phrases']);
-const getPolyglotScope = (state, polyglotScope = '') => (
+const getPolyglotScope = (state, { polyglotScope = '' }) => (
     polyglotScope === '' ? '' : `${polyglotScope}.`
 );
+
+const getPolyglotOptions = (state, { polyglotOptions = {} }) => polyglotOptions;
 
 const getPolyglot = createSelector(
     getLocale,
     getPhrases,
-    (locale, phrases) => new Polyglot({
+    getPolyglotOptions,
+    (locale, phrases, polyglotOptions) => new Polyglot({
         locale,
         phrases,
+        ...polyglotOptions,
     })
 );
 
@@ -35,7 +39,7 @@ const getTranslationMorphed = (...args) => f => compose(f, getTranslation(...arg
 const getTranslationUpperCased = (...args) => getTranslationMorphed(...args)(toUpper);
 const getTranslationCapitalized = (...args) => getTranslationMorphed(...args)(capitalize);
 
-const getP = (state, { polyglotScope } = {}) => {
+const createGetP = (polyglotOptions) => (state, { polyglotScope } = {}) => {
     if (!getLocale(state) || !getPhrases(state)) {
         return {
             t: identity,
@@ -44,13 +48,16 @@ const getP = (state, { polyglotScope } = {}) => {
             tm: identity,
         };
     }
+    const options = { polyglotScope, polyglotOptions };
     return {
-        ...getPolyglot(state, polyglotScope),
-        t: getTranslation(state, polyglotScope),
-        tc: getTranslationCapitalized(state, polyglotScope),
-        tu: getTranslationUpperCased(state, polyglotScope),
-        tm: getTranslationMorphed(state, polyglotScope),
+        ...getPolyglot(state, options),
+        t: getTranslation(state, options),
+        tc: getTranslationCapitalized(state, options),
+        tu: getTranslationUpperCased(state, options),
+        tm: getTranslationMorphed(state, options),
     };
 };
 
-export { getP, getLocale };
+const getP = createGetP();
+
+export { getP, getLocale, createGetP };


### PR DESCRIPTION
In response to #67, expose new `createGetP` function.

it's a selector factory, allowing you to pass polyglot options like `allowMissing`, `onMissingKey` and warn.
