### PR TITLE
Quality Of Life: Export the p PropType

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,16 @@
+import { PropTypes } from 'react';
+
+const PropType = PropTypes.shape({
+    t: PropTypes.func.isRequired,
+    tc: PropTypes.func.isRequired,
+    tt: PropTypes.func.isRequired,
+    tu: PropTypes.func.isRequired,
+    tm: PropTypes.func.isRequired,
+});
+
 export * from './middleware';
 export * from './actions';
 export * from './constants';
 export * from './reducer';
 export * from './selectors';
+export { PropType };


### PR DESCRIPTION
This is small quality of life change that I found helpful when defining our components PropTypes. It adds the `p` prop type's shape and exports it. This lets you do the following for your components, instead of copying the shape:

```javascript
import React, { Component, PropTypes } from 'react';
import { setLanguage, getP, PropType as p } from 'redux-polyglot';

class App extends Component {
  render() { /* ... */ }
}

App.propTypes = {
  children: PropTypes.node,
  p
};
```

