### PR TITLE
Add titleize translation morph

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const polyglotMiddleware = createPolyglotMiddleware(
         // perform async here
         resolve({
             hello: 'bonjour',
-        });        
+        });
     }),
 )
 
@@ -90,6 +90,7 @@ You can use the `getP(state)` selector.
 It returns an object with 4 functions inside :
 - t: String -> String : translation (the original polyglot `t` function)
 - tc: String -> String : translation capitalized
+- tt: String -> String : translation titleized
 - tu: String -> String : translation upper-cased
 - tm: (String -> String) -> String -> String :  translation using a custom morphism
 

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -5,6 +5,7 @@ import { identity } from './private/utils';
 
 const path = arrPath => obj => arrPath.reduce((cursor, key) => cursor && cursor[key], obj);
 const toUpper = str => str.toUpperCase();
+const titleize = str => str.toLowerCase().replace(/(?:^|\s|-)\S/g, c => c.toUpperCase());
 const adjustString = (f, index) => str => (
     str.substr(0, index) + f(str[index]) + str.substr(index + 1)
 );
@@ -38,12 +39,14 @@ const getTranslation = createSelector(
 const getTranslationMorphed = (...args) => f => compose(f, getTranslation(...args));
 const getTranslationUpperCased = (...args) => getTranslationMorphed(...args)(toUpper);
 const getTranslationCapitalized = (...args) => getTranslationMorphed(...args)(capitalize);
+const getTranslationTitleized = (...args) => getTranslationMorphed(...args)(titleize);
 
 const createGetP = (polyglotOptions) => (state, { polyglotScope } = {}) => {
     if (!getLocale(state) || !getPhrases(state)) {
         return {
             t: identity,
             tc: identity,
+            tt: identity,
             tu: identity,
             tm: identity,
         };
@@ -53,6 +56,7 @@ const createGetP = (polyglotOptions) => (state, { polyglotScope } = {}) => {
         ...getPolyglot(state, options),
         t: getTranslation(state, options),
         tc: getTranslationCapitalized(state, options),
+        tt: getTranslationTitleized(state, options),
         tu: getTranslationUpperCased(state, options),
         tm: getTranslationMorphed(state, options),
     };

--- a/src/selectors.spec.js
+++ b/src/selectors.spec.js
@@ -9,6 +9,7 @@ const isValidPolyglot = pipe(
         warn: is(Function),
         t: is(Function),
         tc: is(Function),
+        tt: is(Function),
         tu: is(Function),
         tm: is(Function),
     }),
@@ -19,7 +20,7 @@ const isValidPolyglot = pipe(
 const fakeState = {
     polyglot: {
         locale: 'fr',
-        phrases: { test: { hello: 'bonjour' } },
+        phrases: { test: { hello: 'bonjour', hello_world: 'bonjour monde' } },
     },
 };
 
@@ -55,6 +56,10 @@ describe('selectors', () => {
 
         it('translates "hello" to "Bonjour" (capitalize)', () => {
             expect(p.tc('hello')).toBe('Bonjour');
+        });
+
+        it('translates "hello world" to "Bonjour Monde" (titleize)', () => {
+            expect(p.tt('hello_world')).toBe('Bonjour Monde');
         });
 
         it('translates "hello" to "BONJOUR" (upper-case)', () => {


### PR DESCRIPTION
This PR adds a `titleize` translation under the shorthand `tt`. `titleize` is a string transform inherited from [underscore.string](http://epeli.github.io/underscore.string/#titleize-string-gt-string) that uppercases the first letter of every word ("hello world" -> "Hello World"). The implementation used here, is the same that [underscore.string](https://github.com/epeli/underscore.string/blob/2f78f0d6e36d553484a1bf5fe5ed1998f013dea5/titleize.js) uses. We use this morph a lot internally and I thought it may be common enough to be of use to others.

If this PR goes through and #72 goes through, #72 would need to be updated on it's PropType.