### PR TITLE
Overwrite phrases

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ translate(Dummy);
 translate('catalog', Dummy); // with polyglotScope
 translate()(Dummy); // curried
 translate('catalog')(Dummy); // curried with polyglotScope.
-translate({ polyglotScope : 'some.nested.data', ... })(Dummy); // curried with object configuration.
+translate({ polyglotScope : 'some.nested.data', ownPhrases: 'some.nested.data.hello': 'Hi !', ... })(Dummy); // curried with object configuration.
 ```
 
 ##### get locale in a component

--- a/README.md
+++ b/README.md
@@ -140,12 +140,41 @@ translate(Dummy);
 translate('catalog', Dummy); // with polyglotScope
 translate()(Dummy); // curried
 translate('catalog')(Dummy); // curried with polyglotScope.
+translate({ polyglotScope : 'some.nested.data', ... })(Dummy); // curried with object configuration.
 ```
 
 ##### get locale in a component
 You can use the `getLocale()` selector inside a [mapStateToProps](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options) from react-redux.
 
 Proptype: ````locale: PropTypes.string,````
+
+### Overwrite phrases
+In some case, you should be able to replace some default phrases by others phrases. 
+
+For doing this, you have to define an object which contains your overwrited phrases. 
+This object is composed of : ``` { 'some.nested.data': 'phrase', ... }``` where `key` is the target path you want to replace and `value` ... the new value.
+
+##### with _getP()_ selector
+Add simply `ownPhrases` property and set the new configuration like above to overwrite  :
+```js
+store.dispatch(setLanguage('en', {
+    some: { nested: { data: { hello: 'hello' } } }
+}));
+const p = getP(store.getState(), {
+    polyglotScope: 'some.nested.data', 
+    ownPhrases: { 'some.nested.data.hello': 'Hi !' }
+});
+console.log(p.tc('hello')) // => will return 'Hi !'
+```
+##### with _translate()_ enhancer
+Instead passing only _string_ as parameter : `translate('catalog', Dummy)`, pass a plain _object_ which contains `polyglotScope` and `ownPhrases` properties :
+```js
+translate({ 
+    polyglotScope : 'some.nested.data', 
+    ownPhrases: { 'some.nested.data.catalog': 'Cars' } 
+}, Dummy);
+console.log(p.tc('catalog')) // => will return 'Cars'
+```
 
 ### Use polyglot options
 if you want to use `onMissingKey`, `allowMissing` or `warn` [polyglot](http://airbnb.io/polyglot.js/) options, you can use the `createGetP` function to create a custom `getP`.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ For doing this, you have to define an object which contains your overwrited phra
 This object is composed of : ``` { 'some.nested.data': 'phrase', ... }``` where `key` is the target path you want to replace and `value` ... the new value.
 
 ##### with _getP()_ selector
-Add simply `ownPhrases` property and set the new configuration like above to overwrite  :
+Simply add `ownPhrases` property and set the new configuration like above to overwrite  :
 ```js
 store.dispatch(setLanguage('en', {
     some: { nested: { data: { hello: 'hello' } } }

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -44,7 +44,6 @@ const getTranslation = createSelector(
     getPolyglotScope,
     getPolyglotOwnPhrases,
     (p, polyglotScope, ownPhrases) => (polyglotKey, ...args) => {
-
         const fullPath = polyglotScope + polyglotKey;
         const ownPhrase = (ownPhrases !== '')
             ? ownPhrases[fullPath]

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -46,7 +46,6 @@ const getTranslation = createSelector(
     (p, polyglotScope, ownPhrases) => (polyglotScopeKey, ...args) => {
 
         const fullPath = polyglotScope + polyglotScopeKey;
-
         const ownPhrase = (ownPhrases)
             ? ownPhrases[fullPath]
             : null;

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,7 +1,7 @@
 import { compose } from 'redux';
 import { createSelector } from 'reselect';
 import Polyglot from 'node-polyglot';
-import { identity, isObject } from './private/utils';
+import { identity } from './private/utils';
 
 const path = arrPath => obj => arrPath.reduce((cursor, key) => cursor && cursor[key], obj);
 const toUpper = str => str.toUpperCase();
@@ -15,15 +15,15 @@ const getLocale = path(['polyglot', 'locale']);
 const getPhrases = path(['polyglot', 'phrases']);
 
 const getPolyglotScope = (state, { polyglotScope = '' }) => (
-     (polyglotScope === '')
-        ? ''
-        : `${polyglotScope}.`
+     (polyglotScope !== '')
+        ? `${polyglotScope}.`
+        : ''
 );
 
-const getPolyglotOwnPhrases = (state, polyglotScope) => (
-    (isObject(polyglotScope) && polyglotScope.ownPhrases)
-        ? polyglotScope.ownPhrases
-        : null
+const getPolyglotOwnPhrases = (state, { ownPhrases = '' }) => (
+    (ownPhrases !== '')
+        ? ownPhrases
+        : ''
 );
 
 const getPolyglotOptions = (state, { polyglotOptions }) => polyglotOptions;
@@ -43,10 +43,10 @@ const getTranslation = createSelector(
     getPolyglot,
     getPolyglotScope,
     getPolyglotOwnPhrases,
-    (p, polyglotScope, ownPhrases) => (polyglotScopeKey, ...args) => {
+    (p, polyglotScope, ownPhrases) => (polyglotKey, ...args) => {
 
-        const fullPath = polyglotScope + polyglotScopeKey;
-        const ownPhrase = (ownPhrases)
+        const fullPath = polyglotScope + polyglotKey;
+        const ownPhrase = (ownPhrases !== '')
             ? ownPhrases[fullPath]
             : null;
 

--- a/src/selectors.spec.js
+++ b/src/selectors.spec.js
@@ -76,7 +76,7 @@ describe('selectors', () => {
         });
 
         it('overwrite default scope translation "hello" to "Hi !"', () => {
-            const pBis = getP(fakeState, {
+            const p = getP(fakeState, {
                 polyglotScope: 'test',
                 ownPhrases: { 'test.hello': 'Hi !' },
             });
@@ -84,7 +84,7 @@ describe('selectors', () => {
         });
 
         it('overwrite multiple default scope translations', () => {
-            const pBis = getP(fakeState, {
+            const p = getP(fakeState, {
                 polyglotScope: 'test',
                 ownPhrases: {
                     'test.hello': 'Hi !',

--- a/src/selectors.spec.js
+++ b/src/selectors.spec.js
@@ -74,5 +74,26 @@ describe('selectors', () => {
             expect(getP(fakeState).t('test.hello')).toBe('bonjour');
             expect(getP(fakeState).tu('test.hello')).toBe('BONJOUR');
         });
+
+        it('overwrite default scope translation "hello" to "Hi !"', () => {
+            const pBis = getP(fakeState, {
+                polyglotScope: 'test',
+                ownPhrases: { 'test.hello': 'Hi !' },
+            });
+            expect(pBis.tc('hello')).toBe('Hi !');
+        });
+
+        it('overwrite multiple default scope translations', () => {
+            const pBis = getP(fakeState, {
+                polyglotScope: 'test',
+                ownPhrases: {
+                    'test.hello': 'Hi !',
+                    'test.hello_world': 'Hi WORLD !',
+                },
+            });
+
+            expect(pBis.tc('hello_world')).toBe('Hi WORLD !');
+            expect(pBis.tc('hello')).toBe('Hi !');
+        });
     });
 });

--- a/src/selectors.spec.js
+++ b/src/selectors.spec.js
@@ -76,15 +76,15 @@ describe('selectors', () => {
         });
 
         it('overwrite default scope translation "hello" to "Hi !"', () => {
-            const p = getP(fakeState, {
+            const p1 = getP(fakeState, {
                 polyglotScope: 'test',
                 ownPhrases: { 'test.hello': 'Hi !' },
             });
-            expect(pBis.tc('hello')).toBe('Hi !');
+            expect(p1.tc('hello')).toBe('Hi !');
         });
 
         it('overwrite multiple default scope translations', () => {
-            const p = getP(fakeState, {
+            const p2 = getP(fakeState, {
                 polyglotScope: 'test',
                 ownPhrases: {
                     'test.hello': 'Hi !',
@@ -92,8 +92,8 @@ describe('selectors', () => {
                 },
             });
 
-            expect(pBis.tc('hello_world')).toBe('Hi WORLD !');
-            expect(pBis.tc('hello')).toBe('Hi !');
+            expect(p2.tc('hello_world')).toBe('Hi WORLD !');
+            expect(p2.tc('hello')).toBe('Hi !');
         });
     });
 });

--- a/src/translate.js
+++ b/src/translate.js
@@ -1,14 +1,14 @@
 import curry from 'lodash.curry';
 import { connect } from 'react-redux';
 import { getP } from './selectors';
-import { isFunction, isString } from './private/utils';
+import { isFunction, isString, isObject } from './private/utils';
 
 const getDisplayName = Component => (
     Component.displayName || Component.name || 'Component'
 );
 
 const mapPolyglotToProps = polyglotScope => state => ({
-    p: getP(state, { polyglotScope }),
+    p: getP(state, polyglotScope)
 });
 
 const translateEnhancer = curry((polyglotScope, Component) => {
@@ -22,7 +22,7 @@ const translate = (fstArg, sndArg) => {
         return translateEnhancer('');
     else if (isFunction(fstArg))
         return translateEnhancer('', fstArg);
-    else if (isString(fstArg) && sndArg === undefined)
+    else if ((isString(fstArg) || isObject(fstArg)) && sndArg === undefined)
         return translateEnhancer(fstArg);
     return translateEnhancer(fstArg, sndArg);
 };

--- a/src/translate.js
+++ b/src/translate.js
@@ -7,19 +7,19 @@ const getDisplayName = Component => (
     Component.displayName || Component.name || 'Component'
 );
 
-const mapPolyglotToProps = options => state => ({
+const mapOptionsToProps = options => state => ({
     p: getP(state, options),
 });
 
 const translateEnhancer = curry((polyglotScope, Component) => {
-    const Connected = connect(mapPolyglotToProps(polyglotScope))(Component);
+    const Connected = connect(mapOptionsToProps(polyglotScope))(Component);
     Connected.displayName = `Translated(${getDisplayName(Connected.WrappedComponent)})`;
     return Connected;
 });
 
 const translate = (fstArg, sndArg) => {
     if (fstArg === undefined && sndArg === undefined)
-        return translateEnhancer('');
+        return translateEnhancer({});
 
     else if (isFunction(fstArg))
         return translateEnhancer({ polyglotScope: '' }, fstArg);

--- a/src/translate.js
+++ b/src/translate.js
@@ -7,8 +7,8 @@ const getDisplayName = Component => (
     Component.displayName || Component.name || 'Component'
 );
 
-const mapPolyglotToProps = polyglotScope => state => ({
-    p: getP(state, polyglotScope)
+const mapPolyglotToProps = options => state => ({
+    p: getP(state, options),
 });
 
 const translateEnhancer = curry((polyglotScope, Component) => {
@@ -20,10 +20,16 @@ const translateEnhancer = curry((polyglotScope, Component) => {
 const translate = (fstArg, sndArg) => {
     if (fstArg === undefined && sndArg === undefined)
         return translateEnhancer('');
+
     else if (isFunction(fstArg))
-        return translateEnhancer('', fstArg);
-    else if ((isString(fstArg) || isObject(fstArg)) && sndArg === undefined)
+        return translateEnhancer({ polyglotScope: '' }, fstArg);
+
+    else if (isString(fstArg) && sndArg === undefined)
+        return translateEnhancer({ polyglotScope: fstArg });
+
+    else if (isObject(fstArg) && sndArg === undefined)
         return translateEnhancer(fstArg);
+
     return translateEnhancer(fstArg, sndArg);
 };
 

--- a/src/translate.js
+++ b/src/translate.js
@@ -7,12 +7,12 @@ const getDisplayName = Component => (
     Component.displayName || Component.name || 'Component'
 );
 
-const mapOptionsToProps = options => state => ({
+const mapPolyglotToProps = options => state => ({
     p: getP(state, options),
 });
 
 const translateEnhancer = curry((polyglotScope, Component) => {
-    const Connected = connect(mapOptionsToProps(polyglotScope))(Component);
+    const Connected = connect(mapPolyglotToProps(polyglotScope))(Component);
     Connected.displayName = `Translated(${getDisplayName(Connected.WrappedComponent)})`;
     return Connected;
 });
@@ -22,7 +22,7 @@ const translate = (fstArg, sndArg) => {
         return translateEnhancer({});
 
     else if (isFunction(fstArg))
-        return translateEnhancer({ polyglotScope: '' }, fstArg);
+        return translateEnhancer({}, fstArg);
 
     else if (isString(fstArg) && sndArg === undefined)
         return translateEnhancer({ polyglotScope: fstArg });

--- a/src/translate.spec.js
+++ b/src/translate.spec.js
@@ -50,6 +50,7 @@ describe('translate enhancer', () => {
         expect(translate('')(Dummy).displayName).toEqual(EnhancedComponent.displayName);
         expect(translate({ polyglotScope: '' })(Dummy).displayName).toEqual(EnhancedComponent.displayName);
         expect(translate({ polyglotScope: '', ownPhrases: { hello: 'Hi !' } })(Dummy).displayName).toEqual(EnhancedComponent.displayName);
+        expect(translate({ ownPhrases: { hello: 'Hi !' } })(Dummy).displayName).toEqual(EnhancedComponent.displayName);
     });
 
     describe('displayName', () => {

--- a/src/translate.spec.js
+++ b/src/translate.spec.js
@@ -29,7 +29,6 @@ describe('translate enhancer', () => {
         />
     );
     const EnhancedComponent = translate(DummyComponent);
-
     const tree = renderer.create(
         <Provider store={fakeStore}>
             <EnhancedComponent />
@@ -48,6 +47,8 @@ describe('translate enhancer', () => {
         expect(translate(Dummy).displayName).toEqual(EnhancedComponent.displayName);
         expect(translate('', Dummy).displayName).toEqual(EnhancedComponent.displayName);
         expect(translate('')(Dummy).displayName).toEqual(EnhancedComponent.displayName);
+        expect(translate({ polyglotScope : ''})(Dummy).displayName).toEqual(EnhancedComponent.displayName);
+        expect(translate({ polyglotScope : '', ownPhrases: { 'hello': 'Hi !' } })(Dummy).displayName).toEqual(EnhancedComponent.displayName);
     });
 
     describe('displayName', () => {

--- a/src/translate.spec.js
+++ b/src/translate.spec.js
@@ -48,8 +48,8 @@ describe('translate enhancer', () => {
         expect(translate(Dummy).displayName).toEqual(EnhancedComponent.displayName);
         expect(translate('', Dummy).displayName).toEqual(EnhancedComponent.displayName);
         expect(translate('')(Dummy).displayName).toEqual(EnhancedComponent.displayName);
-        expect(translate({ polyglotScope : ''})(Dummy).displayName).toEqual(EnhancedComponent.displayName);
-        expect(translate({ polyglotScope : '', ownPhrases: { 'hello': 'Hi !' } })(Dummy).displayName).toEqual(EnhancedComponent.displayName);
+        expect(translate({ polyglotScope: '' })(Dummy).displayName).toEqual(EnhancedComponent.displayName);
+        expect(translate({ polyglotScope: '', ownPhrases: { hello: 'Hi !' } })(Dummy).displayName).toEqual(EnhancedComponent.displayName);
     });
 
     describe('displayName', () => {

--- a/src/translate.spec.js
+++ b/src/translate.spec.js
@@ -29,6 +29,7 @@ describe('translate enhancer', () => {
         />
     );
     const EnhancedComponent = translate(DummyComponent);
+
     const tree = renderer.create(
         <Provider store={fakeStore}>
             <EnhancedComponent />


### PR DESCRIPTION
_Readme :_

### Overwrite phrases
In some case, you should be able to replace some default phrases by others phrases. 

For doing this, you have to define an object which contains your overwrited phrases. 
This object is composed of : ``` { 'some.nested.data': 'phrase', ... }``` where `key` is the target path you want to replace and `value` ... the new value.

##### with _getP()_ selector
Add simply `ownPhrases` property and set the new configuration like above to overwrite  :
```js
store.dispatch(setLanguage('en', {
    some: { nested: { data: { hello: 'hello' } } }
}));
const p = getP(store.getState(), {
    polyglotScope: 'some.nested.data', 
    ownPhrases: { 'some.nested.data.hello': 'Hi !' }
});
console.log(p.tc('hello')) // => will return 'Hi !'
```
##### with _translate()_ enhancer
Instead passing only _string_ as parameter : `translate('catalog', Dummy)`, pass a plain _object_ which contains `polyglotScope` and `ownPhrases` properties :
```js
translate({ 
    polyglotScope : 'some.nested.data', 
    ownPhrases: { 'some.nested.data.catalog': 'Cars' } 
}, Dummy);
console.log(p.tc('catalog')) // => will return 'Cars'
```