### PR TITLE
perfomance: Create a new getP selector for each translate instance

### DIFF
--- a/src/selectors.js
+++ b/src/selectors.js
@@ -28,7 +28,7 @@ const getPolyglotOwnPhrases = (state, { ownPhrases = '' }) => (
 
 const getPolyglotOptions = (state, { polyglotOptions }) => polyglotOptions;
 
-const getPolyglot = createSelector(
+const createGetPolyglot = () => createSelector(
     getLocale,
     getPhrases,
     getPolyglotOptions,
@@ -39,8 +39,8 @@ const getPolyglot = createSelector(
     })
 );
 
-const getTranslation = createSelector(
-    getPolyglot,
+const createGetTranslation = () => createSelector(
+    createGetPolyglot(),
     getPolyglotScope,
     getPolyglotOwnPhrases,
     (p, polyglotScope, ownPhrases) => (polyglotKey, ...args) => {
@@ -53,23 +53,23 @@ const getTranslation = createSelector(
     }
 );
 
-const getTranslationMorphed = createSelector(
-    getTranslation,
+const createGetTranslationMorphed = () => createSelector(
+    createGetTranslation(),
     t => f => compose(f, t)
 );
 
-const getTranslationUpperCased = createSelector(
-    getTranslationMorphed,
+const createGetTranslationUpperCased = () => createSelector(
+    createGetTranslationMorphed(),
     m => m(toUpper)
 );
 
-const getTranslationCapitalized = createSelector(
-    getTranslationMorphed,
+const createGetTranslationCapitalized = () => createSelector(
+    createGetTranslationMorphed(),
     m => m(capitalize)
 );
 
-const getTranslationTitleized = createSelector(
-    getTranslationMorphed,
+const createGetTranslationTitleized = () => createSelector(
+    createGetTranslationMorphed(),
     m => m(titleize)
 );
 
@@ -78,12 +78,12 @@ const createGetP = (polyglotOptions) => {
     const getP = createSelector(
         getLocale,
         getPhrases,
-        getPolyglot,
-        getTranslation,
-        getTranslationCapitalized,
-        getTranslationTitleized,
-        getTranslationUpperCased,
-        getTranslationMorphed,
+        createGetPolyglot(),
+        createGetTranslation(),
+        createGetTranslationCapitalized(),
+        createGetTranslationTitleized(),
+        createGetTranslationUpperCased(),
+        createGetTranslationMorphed(),
         (locale, phrases, p, t, tc, tt, tu, tm) => {
             if (!locale || !phrases) {
                 return {

--- a/src/translate.js
+++ b/src/translate.js
@@ -1,15 +1,19 @@
 import curry from 'lodash.curry';
 import { connect } from 'react-redux';
-import { getP } from './selectors';
+import { createGetP } from './selectors';
 import { isFunction, isString, isObject } from './private/utils';
 
 const getDisplayName = Component => (
     Component.displayName || Component.name || 'Component'
 );
 
-const mapPolyglotToProps = options => state => ({
-    p: getP(state, options),
-});
+const mapPolyglotToProps = (options) => () => {
+    const getP = createGetP();
+
+    return state => ({
+        p: getP(state, options),
+    });
+};
 
 const translateEnhancer = curry((polyglotScope, Component) => {
     const Connected = connect(mapPolyglotToProps(polyglotScope))(Component);

--- a/src/translate.spec.js
+++ b/src/translate.spec.js
@@ -11,7 +11,7 @@ import translate from './translate';
 const dummyReducer = (state = '', action) => (action.type === 'DUMMY' ? action.payload : state);
 const createRootReducer = () => combineReducers({ polyglot: polyglotReducer, dummy: dummyReducer });
 const fakeStore = createStore(createRootReducer(), {
-    polyglot: { locale: 'en', phrases: { hello: 'hello' } },
+    polyglot: { locale: 'en', phrases: { hello: 'hello', scope1: { hello: 'hello2' }, scope2: { hello: 'hello3' } } },
 });
 
 const createAnonymousComponent = () => () => (<div />);
@@ -108,5 +108,88 @@ describe('translate enhancer', () => {
 
         expect(nbDispatch).toBe(1);
         expect(pChanged).toBe(false);
+    });
+
+    it('should not re-render component on every non-related dispatch call when there are multiple translate with different options', async () => {
+        let pChanged1 = false;
+        let pChanged2 = false;
+        let pChanged3 = false;
+        let pChanged4 = false;
+        let nbDispatch = 0;
+
+        class TestComponent1 extends PureComponent {
+            componentWillReceiveProps(nextProps) {
+                if (nextProps.p !== this.props.p) pChanged1 = true;
+            }
+
+            render() {
+                return <div data-t={this.props.p.t('hello')} />;
+            }
+        }
+
+        class TestComponent2 extends PureComponent {
+            componentWillReceiveProps(nextProps) {
+                if (nextProps.p !== this.props.p) pChanged2 = true;
+            }
+
+            render() {
+                return <div data-t={this.props.p.t('hello')} />;
+            }
+        }
+
+        class TestComponent3 extends PureComponent {
+            componentWillReceiveProps(nextProps) {
+                if (nextProps.p !== this.props.p) pChanged3 = true;
+            }
+
+            render() {
+                return <div data-t={this.props.p.t('hello')} />;
+            }
+        }
+
+        class TestComponent4 extends PureComponent {
+            componentWillReceiveProps(nextProps) {
+                if (nextProps.p !== this.props.p) pChanged4 = true;
+            }
+
+            render() {
+                return <div data-t={this.props.p.t('hello')} />;
+            }
+        }
+
+        class UnrelatedComponent extends PureComponent {
+            componentDidMount() {
+                nbDispatch += 1;
+                this.props.dispatch({ type: 'DUMMY', payload: 're-render on every dispatch' });
+            }
+
+            render() {
+                return <div>{ this.props.dummy }</div>;
+            }
+        }
+
+        const EnhancedTestComponent1 = translate()(TestComponent1);
+        const EnhancedTestComponent2 = translate('scope1')(TestComponent2);
+        const EnhancedTestComponent3 = translate('scope2')(TestComponent3);
+        const EnhancedTestComponent4 = translate(TestComponent4);
+        const ConnectedUnrelatedComponent = connect((state) => ({ dummy: state.dummy }))(UnrelatedComponent);
+
+        renderer.create(
+            <Provider store={fakeStore}>
+                <div>
+                    <EnhancedTestComponent1 />
+                    <EnhancedTestComponent2 />
+                    <EnhancedTestComponent3 />
+                    <EnhancedTestComponent4 />
+                    <ConnectedUnrelatedComponent />
+                </div>
+            </Provider>
+        ).toJSON();
+
+        expect(nbDispatch).toBe(1);
+        expect(pChanged1).toBe(false);
+        expect(pChanged2).toBe(false);
+        expect(pChanged3).toBe(false);
+        expect(pChanged4).toBe(false);
     });
 });


### PR DESCRIPTION
**Problematic**
Atm there is a global getP selector for all the translate hoc components. As soon as a translate hoc is added to a page with custom options, for instance the option polyglotScope, it will mess with all the other existent translates as the reselect selector only keep cache of one element and we are passing these options as selector props.

**Solution**
Create a new getP selector for each translate, so each instance keeps their own cache instead of conflicting with all the other translates.

Any other ideas of how to tackle this issue?

@satazor